### PR TITLE
Add separate pipeline for sbox

### DIFF
--- a/azure-pipelines-sbox.yml
+++ b/azure-pipelines-sbox.yml
@@ -1,0 +1,41 @@
+trigger: none
+pr: none
+schedules:
+- cron: '0 8-17/3 * * *'
+  displayName: Run update every 3 hours between 9am and 6pm GMT
+  branches:
+    include:
+    - master
+  always: 'true'
+jobs:
+  - job: owasp_update_flexible_sbox
+    displayName: Update OWASP dependency check DB on Postgres Flexible Server - Sandbox
+    pool:
+      name: 'hmcts-sandbox-agent-pool'
+    variables:
+      serviceConnection: azurerm-sandbox
+      keyvaultName: cftsbox-intsvc
+    timeoutInMinutes: 600
+    steps:
+      - task: AzureKeyVault@1
+        displayName: 'Get secrets from Keyvault'
+        inputs:
+          azureSubscription: ${{ variables.serviceConnection }}
+          keyVaultName: ${{ variables.keyvaultName }}
+          secretsFilter: 'OWASPPostgresDb-v14-Password,OWASPPostgresDb-v14-Account'
+
+      - task: Gradle@2
+        displayName: 'Running OWASP DB migrations'
+        inputs:
+          gradleWrapperFile: 'gradlew'
+          options: "--build-file build-v6.gradle -DfailBuild='true' -Dflyway.url=jdbc:postgresql://owaspdependency-v14-flexible-sandbox.postgres.database.azure.com/owaspdependencycheck -Dflyway.user=$(OWASPPostgresDb-v14-Account) -Dflyway.password=$(OWASPPostgresDb-v14-Password) -Dflyway.locations=filesystem:db-migrations/v6"
+          tasks: 'flywayMigrate'
+          gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
+
+      - task: Gradle@2
+        displayName: 'Updating OWASP DB'
+        inputs:
+          gradleWrapperFile: 'gradlew'
+          options: "--build-file build-v6.gradle -DfailBuild='true' -Dcve.check.validforhours=24 -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v14-flexible-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v14-Account) -Ddata.password=$(OWASPPostgresDb-v14-Password) -Ddatabase.batchinsert.enabled='true'"
+          tasks: 'dependencyCheckUpdate'
+          gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,35 +40,3 @@ jobs:
           options: "--build-file build-v6.gradle -DfailBuild='true' -Dcve.check.validforhours=24 -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v14-flexible-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v14-Account) -Ddata.password=$(OWASPPostgresDb-v14-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: 'dependencyCheckUpdate'
           gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
-
-  - job: owasp_update_flexible_sbox
-    displayName: Update OWASP dependency check DB on Postgres Flexible Server - Sandbox
-    pool:
-      name: 'hmcts-sandbox-agent-pool'
-    variables:
-      serviceConnection: azurerm-sandbox
-      keyvaultName: cftsbox-intsvc
-    timeoutInMinutes: 600
-    steps:
-      - task: AzureKeyVault@1
-        displayName: 'Get secrets from Keyvault'
-        inputs:
-          azureSubscription: ${{ variables.serviceConnection }}
-          keyVaultName: ${{ variables.keyvaultName }}
-          secretsFilter: 'OWASPPostgresDb-v14-Password,OWASPPostgresDb-v14-Account'
-
-      - task: Gradle@2
-        displayName: 'Running OWASP DB migrations'
-        inputs:
-          gradleWrapperFile: 'gradlew'
-          options: "--build-file build-v6.gradle -DfailBuild='true' -Dflyway.url=jdbc:postgresql://owaspdependency-v14-flexible-sandbox.postgres.database.azure.com/owaspdependencycheck -Dflyway.user=$(OWASPPostgresDb-v14-Account) -Dflyway.password=$(OWASPPostgresDb-v14-Password) -Dflyway.locations=filesystem:db-migrations/v6"
-          tasks: 'flywayMigrate'
-          gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
-
-      - task: Gradle@2
-        displayName: 'Updating OWASP DB'
-        inputs:
-          gradleWrapperFile: 'gradlew'
-          options: "--build-file build-v6.gradle -DfailBuild='true' -Dcve.check.validforhours=24 -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-v14-flexible-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v14-Account) -Ddata.password=$(OWASPPostgresDb-v14-Password) -Ddatabase.batchinsert.enabled='true'"
-          tasks: 'dependencyCheckUpdate'
-          gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
### Change description ###
Sbox job is using ptlsbox agent which is affected by aks cluster auto shutdown
Changing schedule so db only gets updated when cluster is running to avoid many long running jobs showing up in the log

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
