### PR TITLE
Revert to change from pr 37

### DIFF
--- a/db-migrations/v6/V008__upgrade_5_4.sql
+++ b/db-migrations/v6/V008__upgrade_5_4.sql
@@ -40,4 +40,4 @@ ALTER TABLE vulnerability ADD COLUMN v4environmentalSeverity VARCHAR(15);
 ALTER TABLE vulnerability ADD COLUMN v4source VARCHAR(50);
 ALTER TABLE vulnerability ADD COLUMN v4type VARCHAR(15);
 
-UPDATE Properties SET `value`='5.4' WHERE ID='version';
+UPDATE Properties SET value='5.4' WHERE ID='version';


### PR DESCRIPTION
https://github.com/hmcts/cnp-owaspdependencycheck-update/pull/37

37 did run migrations: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=612963&view=logs&j=7c4f4658-570f-53dc-23a0-288c15eb5010

36 didn't: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=612935&view=logs&j=7c4f4658-570f-53dc-23a0-288c15eb5010&t=dfa081a2-86e8-58dc-589f-0c4ccb883a2b

Going to 37 to fix   Validate failed: Migrations have failed validation
  Migration checksum mismatch for migration version 008

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
