### PR TITLE
Upgrades

### DIFF
--- a/build-v10.gradle
+++ b/build-v10.gradle
@@ -4,11 +4,11 @@ buildscript {
     }
 
     dependencies {
-        classpath  group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
+        classpath  group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
     }
 }
 plugins {
-    id "org.flywaydb.flyway" version "8.5.13"
+    id "org.flywaydb.flyway" version "10.15.2"
     id 'org.owasp.dependencycheck' version '10.0.3'
 }
 

--- a/db-migrations/v6/V009__upgrade_5_4.sql
+++ b/db-migrations/v6/V009__upgrade_5_4.sql
@@ -1,0 +1,1 @@
+UPDATE Properties SET value='5.5' WHERE ID='version';


### PR DESCRIPTION
Warning in sbox pipeline about old versions being used

Version needs to be 5.5 https://github.com/jeremylong/DependencyCheck/blob/main/core/src/main/resources/data/upgrade_5.4.sql#L43 but cannot just edit a migration that has already ran (will fail due to checksum mismatch)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
