### PR TITLE
Sandbox: correct and verify updated failBuild to failOnError

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/en/articles/about-code-owners
+
+CODEOWNERS @hmcts/platform-operations

--- a/azure-pipelines-sbox.yml
+++ b/azure-pipelines-sbox.yml
@@ -37,6 +37,6 @@ jobs:
         displayName: "Updating OWASP V15 DB"
         inputs:
           gradleWrapperFile: "gradlew"
-          options: "--build-file build-v10.gradle -DfailBuild='true' -Dcve.check.validforhours=24 -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: "dependencyCheckUpdate"
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
### Jira link

[DTSPO-23398](https://tools.hmcts.net/jira/browse/DTSPO-23398)

### Change description

failBuild='true' from docs looks to now be failOnError - might be why we have had passing builds that weren't doing all our updates.
https://github.com/jeremylong/DependencyCheck/blob/v10.0.4/src/site/markdown/dependency-check-gradle/configuration-update.md#configuration
Removed: -Dcve.check.validforhours=24 - it's already 4 hours by default. - also not been in use in some time as it has changed to nvd.validforhours
https://github.com/jeremylong/DependencyCheck/blob/v10.0.4/src/site/markdown/dependency-check-gradle/configuration-update.md#advanced-configuration

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
