### PR TITLE
fix for ptl, and upgrade (tested on sbox already)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,6 @@ jobs:
         displayName: 'Updating OWASP V15 DB'
         inputs:
           gradleWrapperFile: 'gradlew'
-          options: "--build-file build-v9.gradle -DfailOnError='true' -Dnvd.api.key=$(OWASP-NVD-API-KEY-Password) -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v9.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: 'dependencyCheckUpdate'
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError

--- a/build-v9.gradle
+++ b/build-v9.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 plugins {
     id "org.flywaydb.flyway" version "9.22.3"
-    id 'org.owasp.dependencycheck' version '11.0.0'
+    id 'org.owasp.dependencycheck' version '12.0.2'
 }
 
 group = 'uk.gov.hmcts'


### PR DESCRIPTION
### Jira link

DTSPO-23398

### Change description

Found issue on ptl: -Dnvd.api.key=$(nvd-api-key) was already set. Reason that prod is struggling to pull is probably due to not having key correctly set as it is duplicated.

Also upgraded org.owasp.dependencycheck plugin to latest (already tested on sbox).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
