### PR TITLE
Platops/dstpo 32997owasp nvd download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ build
 
 # IDE
 .idea/
+
+# DTSPO-32997: local NVD datafeed cache + vulnz CLI (never commit these)
+cache/
+nvd-cache.log
+vulnz-*.jar

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Pipeline for automating owasp dependency check updates to Azure DB.
 
 | File | Purpose |
 | ---- | ------- |
-| `azure-pipelines.yml` | Production: Flyway-migrates the shared cached OWASP DB then refreshes the NVD data (every 3h). |
+| `azure-pipelines.yml` | Production: Flyway-migrates the shared cached OWASP DB then refreshes the NVD data from the blob mirror (every 3h). |
 | `azure-pipelines-sbox.yml` | Sandbox equivalent of the production pipeline. |
-| `azure-pipelines-nvd-mirror.yml` | DTSPO-32997 Option B: mirrors the NVD datafeed to Blob Storage (see below). |
+| `azure-pipelines-nvd-mirror.yml` | DTSPO-32997 Option B: builds the NVD datafeed and publishes it to Blob Storage; the producer that prod/sbox read (see below). |
 | `azure-pipelines-nvd-seed.yml` | DTSPO-32997 interim: one-off manual job to seed the DB from a local NVD cache (see below). |
 
 The active jobs use `build-v10.gradle` and `db-migrations/v10`. `build-v6.gradle`
@@ -49,22 +49,61 @@ Azure Blob Storage. DependencyCheck then consumes the feed via
 downloads (hours -> minutes) and decoupling consumers from NVD outages — a failed
 mirror run leaves the previously published copy in place.
 
-### Rollout steps
+### Realised setup
 
-1. **Provision storage**: a storage account + blob container (e.g. `<account>/nvd`)
-   reachable by the prod agent pool and the downstream Jenkins builds. Give the
-   `azurerm-prod` service-connection principal `Storage Blob Data Contributor`.
-2. **Consumer read access**: enable anonymous read on the container, or generate a
-   long-lived read SAS to append to the datafeed URL.
-3. **Configure the mirror pipeline**: set `storageAccount` (and `vulnzVersion` if
-   newer) in `azure-pipelines-nvd-mirror.yml`. Ensure the agent has Java 17+
-   (vulnz 8.0.0+ requirement) or use the Docker alternative noted in the file.
-4. **Run the mirror** and confirm `cache.properties` + `nvdcve-*.json.gz` land in
-   the container.
-5. **Wire up consumers**: set `nvdDatafeedUrl` to
-   `https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz` and append
-   `-Dnvd.api.datafeed.url=$(nvdDatafeedUrl)` to the `Updating OWASP V15 DB`
-   options — **on sandbox first**, then production once validated.
-6. **Downstream builds** (e.g. `dependencyCheckAggregate` in the Jenkins pipeline
-   library) should set the same `nvd.api.datafeed.url` so they never fall back to
-   the live API when the shared cache is stale.
+| Thing | Value |
+| ----- | ----- |
+| Subscription | `DTS-CFTPTL-INTSVC` |
+| Resource group | `core-infra-intsvc-rg` (uksouth) |
+| Storage account | `owaspnvdmirrorcftptl` (private, no public blob access) |
+| Container | `nvd` |
+| Datafeed URL | `https://owaspnvdmirrorcftptl.blob.core.windows.net/nvd/nvdcve-{0}.json.gz?<SAS>` |
+| Read SAS | Key Vault secret `nvd-datafeed-sas`, container-scoped `rl`, 90-day expiry |
+
+The container stays private. Consumers read it with a **rotated read SAS**: the
+mirror mints a fresh 90-day container SAS on every run and stores it in Key Vault
+as `nvd-datafeed-sas`, so the token is always renewed long before it expires (no
+manual rotation, no silent 403s). Because prod reads `cftptl-intsvc` but sbox
+reads `cftsbox-intsvc`, the mirror writes the same token to **both** vaults each
+run (the blob itself lives only in the prod subscription; the SAS is just a URL
+query string, so no cross-subscription RBAC is needed to consume it).
+
+### How it runs
+
+- **Schedule**: the mirror runs every 6h on the prod pool (`hmcts-cftptl-agent-pool`,
+  3h cap), seeding from the existing blob copy and updating incrementally.
+- **Full rebuild**: run the mirror manually with the `fullRebuild` parameter set
+  to `true` to force a clean ~7h pull from NVD on the 9h sandbox pool
+  (`hmcts-sandbox-agent-pool`) — e.g. if the blob mirror is ever lost or
+  corrupted. The mirror is decoupled from consumers, so a long full run blocks
+  nobody.
+- **Cold-start note**: the initial blob contents were built off-agent (a local
+  ~7h authenticated `vulnz` run) and uploaded once, because a from-scratch pull
+  exceeds the prod pool's 3h cap. Routine runs only need the incremental path.
+
+### Consumer wiring (already in place)
+
+Both `azure-pipelines.yml` and `azure-pipelines-sbox.yml`:
+
+- add `nvd-datafeed-sas` to the `AzureKeyVault@2` `secretsFilter`;
+- set `nvdDatafeedUrl` to the blob base URL above;
+- append `-Dnvd.api.datafeed.url=$(nvdDatafeedUrl)?$(nvd-datafeed-sas)` to the
+  `Updating OWASP V15 DB` (`dependencyCheckUpdate`) options.
+
+`-Dnvd.api.key` is kept only for the small recent "modified" window; the bulk
+yearly data now comes from the blob mirror.
+
+### RBAC the mirror needs
+
+- `azurerm-prod` SP on `owaspnvdmirrorcftptl`: `Storage Blob Data Contributor`
+  (upload/download with `--auth-mode login`) **and** the ability to list account
+  keys (`Contributor` or *Storage Account Key Operator Service Role*), plus `set`
+  on secrets in `cftptl-intsvc`.
+- `azurerm-sandbox` SP: `set` on secrets in `cftsbox-intsvc` (already granted via
+  the sbox pipelines).
+
+### Downstream builds
+
+Downstream consumers (e.g. `dependencyCheckAggregate` in the Jenkins pipeline
+library) should set the same `nvd.api.datafeed.url` so they never fall back to the
+live API when the shared cache is stale.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
 # cnp-owaspdependencycheck-update
-Pipeline for automating owasp dependency check updates to Azure DB
+
+Pipeline for automating owasp dependency check updates to Azure DB.
+
+## Pipelines
+
+| File | Purpose |
+| ---- | ------- |
+| `azure-pipelines.yml` | Production: Flyway-migrates the shared cached OWASP DB then refreshes the NVD data (every 3h). |
+| `azure-pipelines-sbox.yml` | Sandbox equivalent of the production pipeline. |
+| `azure-pipelines-nvd-mirror.yml` | DTSPO-32997 Option B: mirrors the NVD datafeed to Blob Storage (see below). |
+| `azure-pipelines-nvd-seed.yml` | DTSPO-32997 interim: one-off manual job to seed the DB from a local NVD cache (see below). |
+
+The active jobs use `build-v10.gradle` and `db-migrations/v10`. `build-v6.gradle`
+and `build-v9.gradle` are legacy and unused.
+
+## One-off seed (DTSPO-32997 interim, no new infra)
+
+When the shared DB has gone stale and the live-API update can't catch up (NVD
+HTTP/2 instability + bulk re-modification of CVEs makes each "incremental" pull
+behave like a full download), use `azure-pipelines-nvd-seed.yml` to get the DB
+current without paging the live API:
+
+1. The job builds a local NVD cache on the agent with
+   [open-vulnerability-cli](https://github.com/jeremylong/open-vulnerability-cli)
+   (`vulnz cve --cache --directory ./cache`). This is resumable — if the cache
+   build is interrupted, re-run the job and completed year files are kept.
+2. It then loads that cache into Postgres in one fast pass via DependencyCheck's
+   datafeed support (`-Dnvd.api.datafeed.url=file:.../cache/nvdcve-{0}.json.gz`),
+   so the DB load never touches the live NVD API.
+
+Run it **manually**, `environment: sandbox` first to validate, then `prod`.
+Requires Java 17 on the agent (vulnz 8.0.0+); the job uses `JAVA_HOME_17_X64` if
+present, otherwise see the Docker alternative in the pipeline file. Once seeded,
+the normal scheduled pipeline resumes small, fast incremental updates.
+
+## NVD datafeed mirror (DTSPO-32997, Option B)
+
+The live NVD API is unstable (HTTP/2 stream resets). Paging it directly makes the
+DB update take many hours, frequently aborting or losing the agent, which in turn
+leaves the shared cache stale and breaks downstream consumer builds.
+
+`azure-pipelines-nvd-mirror.yml` mirrors the NVD CVE data with the
+[open-vulnerability-cli](https://github.com/jeremylong/open-vulnerability-cli)
+(`vulnz cve --cache --directory ./cache`) and publishes the gzipped yearly feed
+files (`nvdcve-<year>.json.gz`, `nvdcve-modified.json.gz`, `cache.properties`) to
+Azure Blob Storage. DependencyCheck then consumes the feed via
+`-Dnvd.api.datafeed.url`, turning ~170 paged API calls into a handful of gz
+downloads (hours -> minutes) and decoupling consumers from NVD outages — a failed
+mirror run leaves the previously published copy in place.
+
+### Rollout steps
+
+1. **Provision storage**: a storage account + blob container (e.g. `<account>/nvd`)
+   reachable by the prod agent pool and the downstream Jenkins builds. Give the
+   `azurerm-prod` service-connection principal `Storage Blob Data Contributor`.
+2. **Consumer read access**: enable anonymous read on the container, or generate a
+   long-lived read SAS to append to the datafeed URL.
+3. **Configure the mirror pipeline**: set `storageAccount` (and `vulnzVersion` if
+   newer) in `azure-pipelines-nvd-mirror.yml`. Ensure the agent has Java 17+
+   (vulnz 8.0.0+ requirement) or use the Docker alternative noted in the file.
+4. **Run the mirror** and confirm `cache.properties` + `nvdcve-*.json.gz` land in
+   the container.
+5. **Wire up consumers**: set `nvdDatafeedUrl` to
+   `https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz` and append
+   `-Dnvd.api.datafeed.url=$(nvdDatafeedUrl)` to the `Updating OWASP V15 DB`
+   options — **on sandbox first**, then production once validated.
+6. **Downstream builds** (e.g. `dependencyCheckAggregate` in the Jenkins pipeline
+   library) should set the same `nvd.api.datafeed.url` so they never fall back to
+   the live API when the shared cache is stale.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ mirror run leaves the previously published copy in place.
 | Resource group | `core-infra-intsvc-rg` (uksouth) |
 | Storage account | `owaspnvdmirrorcftptl` (private, no public blob access) |
 | Container | `nvd` |
-| Datafeed URL | `https://owaspnvdmirrorcftptl.blob.core.windows.net/nvd/nvdcve-{0}.json.gz?<SAS>` |
-| Read SAS | Key Vault secret `nvd-datafeed-sas`, container-scoped `rl`, 90-day expiry |
+| Datafeed (consumer-side) | feeds downloaded to `./cache`, read by ODC via `file:$(System.DefaultWorkingDirectory)/cache/nvdcve-{0}.json.gz` |
+| Read SAS | Key Vault secret `nvd-datafeed-sas`, container-scoped `rl`, 90-day expiry (used by `az` to download, not by ODC) |
 
 The container stays private. Consumers read it with a **rotated read SAS**: the
 mirror mints a fresh 90-day container SAS on every run and stores it in Key Vault
@@ -83,15 +83,25 @@ query string, so no cross-subscription RBAC is needed to consume it).
 
 ### Consumer wiring (already in place)
 
+DependencyCheck builds each feed / `cache.properties` URL by string-appending to
+the configured datafeed URL, so it **cannot** consume a blob URL that carries a
+`?<SAS>` query string (it ends up requesting `...nvdcve-{0}.json.gz?<SAS>/cache.properties`
+and fails with `Invalid NVD Cache / Data Feed URL`). The container is private, so
+we can't use a clean anonymous URL either. The consumers therefore **download the
+feeds locally first, then read them via a `file:` URL** (the same approach as the
+seed pipeline).
+
 Both `azure-pipelines.yml` and `azure-pipelines-sbox.yml`:
 
 - add `nvd-datafeed-sas` to the `AzureKeyVault@2` `secretsFilter`;
-- set `nvdDatafeedUrl` to the blob base URL above;
-- append `-Dnvd.api.datafeed.url=$(nvdDatafeedUrl)?$(nvd-datafeed-sas)` to the
-  `Updating OWASP V15 DB` (`dependencyCheckUpdate`) options.
+- add an `AzureCLI@2` step that runs
+  `az storage blob download-batch --account-name owaspnvdmirrorcftptl --source nvd --destination cache --sas-token <SAS>`
+  (the SAS authenticates `az`, no blob RBAC needed and no cross-subscription grant);
+- set `-Dnvd.api.datafeed.url=file:$(System.DefaultWorkingDirectory)/cache/nvdcve-{0}.json.gz`
+  on the `Updating OWASP V15 DB` (`dependencyCheckUpdate`) step.
 
 `-Dnvd.api.key` is kept only for the small recent "modified" window; the bulk
-yearly data now comes from the blob mirror.
+yearly data now comes from the local copy of the mirror.
 
 ### RBAC the mirror needs
 

--- a/azure-pipelines-nvd-mirror.yml
+++ b/azure-pipelines-nvd-mirror.yml
@@ -1,0 +1,126 @@
+# =============================================================================
+# DTSPO-32997 — NVD datafeed mirror (Option B)
+# =============================================================================
+#
+# Purpose
+#   Build a local mirror of the NVD CVE data with the open-vulnerability-cli
+#   (https://github.com/jeremylong/open-vulnerability-cli) and publish the
+#   gzipped yearly feed files to Azure Blob Storage. DependencyCheck consumers
+#   (this repo's DB-update pipelines and the downstream service builds) then read
+#   the feed via -Dnvd.api.datafeed.url instead of paging the flaky NVD live API.
+#
+# Why
+#   The live NVD API is unstable (HTTP/2 stream resets), which makes the paged
+#   update take many hours and frequently abort or kill the agent. The CLI
+#   mirror is resilient (resumable, retrying) and — critically — if a mirror run
+#   fails, the previously published copy stays in blob storage, so consumers are
+#   never blocked. Consuming the datafeed is a handful of gz downloads instead of
+#   ~170 paged API calls, so the DB update drops from hours to minutes.
+#
+# Prerequisites (provision BEFORE enabling the schedule)
+#   1. A storage account + blob container (e.g. <account>/nvd) reachable by the
+#      prod agent pool AND the downstream Jenkins builds.
+#   2. Read access for consumers: either anonymous (public) read on the container
+#      OR a long-lived read SAS appended to the datafeed URL.
+#   3. The pipeline's service-connection principal (azurerm-prod) needs
+#      "Storage Blob Data Contributor" on the storage account (for the upload).
+#   4. Key Vault secret 'nvd-api-key' (already present in cftptl-intsvc).
+#   5. Agent must have Java 17+ available (vulnz 8.0.0+ requires it). If the pool
+#      only has Java 11, either add a JavaToolInstaller step or use the Docker
+#      alternative noted in the "Build NVD datafeed cache" step below.
+#
+# Consumer wiring (see azure-pipelines.yml / azure-pipelines-sbox.yml)
+#   -Dnvd.api.datafeed.url=https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz
+#   ({0} is substituted with the year; cache.properties must sit alongside.)
+# =============================================================================
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 */6 * * *"
+    displayName: Mirror NVD datafeed every 6 hours
+    branches:
+      include:
+        - master
+    always: "true"
+
+variables:
+  serviceConnection: azurerm-prod
+  keyvaultName: cftptl-intsvc
+  # TODO(DTSPO-32997): set to the provisioned storage account + container.
+  storageAccount: "REPLACE_WITH_STORAGE_ACCOUNT"
+  storageContainer: "nvd"
+  # Pin to a verified release of open-vulnerability-cli (vulnz).
+  vulnzVersion: "9.0.4"
+
+jobs:
+  - job: nvd_mirror
+    displayName: Mirror NVD datafeed to Blob Storage
+    pool:
+      name: "hmcts-cftptl-agent-pool"
+    timeoutInMinutes: 120
+    steps:
+      - task: AzureKeyVault@2
+        displayName: "Get secrets from Keyvault"
+        inputs:
+          azureSubscription: ${{ variables.serviceConnection }}
+          keyVaultName: ${{ variables.keyvaultName }}
+          secretsFilter: "nvd-api-key"
+          RunAsPreJob: true
+
+      - task: Bash@3
+        displayName: "Download open-vulnerability-cli (vulnz)"
+        inputs:
+          targetType: inline
+          script: |
+            set -euo pipefail
+            JAR="vulnz-${VULNZ_VERSION}.jar"
+            URL="https://github.com/jeremylong/open-vulnerability-cli/releases/download/v${VULNZ_VERSION}/${JAR}"
+            echo "Downloading ${URL}"
+            curl -sSfL "${URL}" -o "${JAR}"
+            chmod +x "${JAR}"
+        env:
+          VULNZ_VERSION: $(vulnzVersion)
+
+      - task: Bash@3
+        displayName: "Build NVD datafeed cache"
+        inputs:
+          targetType: inline
+          script: |
+            set -euo pipefail
+            rm -rf cache && mkdir -p cache
+            # vulnz 8.0.0+ needs Java 17. Verify the agent's java:
+            java -version
+            # Produces cache.properties, nvdcve-modified.json.gz and
+            # nvdcve-<year>.json.gz (+ .meta files) under ./cache
+            java -Xmx2g -XX:+UseStringDeduplication \
+              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache
+            echo "----- cache contents -----"
+            ls -lh cache
+            # Docker alternative (if the agent lacks Java 17 but has Docker):
+            #   docker run --rm -e NVD_API_KEY="${NVD_API_KEY}" -e JAVA_OPT=-Xmx2g \
+            #     -v "$(pwd)/cache:/usr/local/apache2/htdocs" \
+            #     jeremylong/open-vulnerability-data-mirror:v${VULNZ_VERSION} \
+            #     /mirror.sh
+        env:
+          VULNZ_VERSION: $(vulnzVersion)
+          NVD_API_KEY: $(nvd-api-key)
+
+      - task: AzureCLI@2
+        displayName: "Publish datafeed to Blob Storage"
+        inputs:
+          azureSubscription: ${{ variables.serviceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            # Upload the whole cache (gz feeds, .meta files and cache.properties).
+            # Do NOT set content-encoding: gzip — DependencyCheck expects the raw
+            # .gz bytes and decompresses them itself.
+            az storage blob upload-batch \
+              --account-name "$(storageAccount)" \
+              --destination "$(storageContainer)" \
+              --source cache \
+              --overwrite true \
+              --auth-mode login

--- a/azure-pipelines-nvd-mirror.yml
+++ b/azure-pipelines-nvd-mirror.yml
@@ -20,18 +20,22 @@
 # Prerequisites (provision BEFORE enabling the schedule)
 #   1. A storage account + blob container (e.g. <account>/nvd) reachable by the
 #      prod agent pool AND the downstream Jenkins builds.
-#   2. Read access for consumers: either anonymous (public) read on the container
-#      OR a long-lived read SAS appended to the datafeed URL.
-#   3. The pipeline's service-connection principal (azurerm-prod) needs
-#      "Storage Blob Data Contributor" on the storage account (for the upload).
+#   2. Read access for consumers via a rotated read SAS: this pipeline mints a
+#      fresh container SAS each run and stores it in Key Vault secret
+#      'nvd-datafeed-sas'. The container itself stays private (no public access).
+#   3. The pipeline's service-connection principal (azurerm-prod) needs, on the
+#      storage account: "Storage Blob Data Contributor" (upload/download) and the
+#      ability to list account keys (e.g. Contributor or Storage Account Key
+#      Operator), plus "set" on Key Vault secrets in cftptl-intsvc (SAS rotation).
 #   4. Key Vault secret 'nvd-api-key' (already present in cftptl-intsvc).
 #   5. Agent must have Java 17+ available (vulnz 8.0.0+ requires it). If the pool
 #      only has Java 11, either add a JavaToolInstaller step or use the Docker
 #      alternative noted in the "Build NVD datafeed cache" step below.
 #
 # Consumer wiring (see azure-pipelines.yml / azure-pipelines-sbox.yml)
-#   -Dnvd.api.datafeed.url=https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz
+#   -Dnvd.api.datafeed.url=https://owaspnvdmirrorcftptl.blob.core.windows.net/nvd/nvdcve-{0}.json.gz?<SAS>
 #   ({0} is substituted with the year; cache.properties must sit alongside.)
+#   <SAS> comes from Key Vault secret 'nvd-datafeed-sas' (fetched at build time).
 # =============================================================================
 
 trigger: none
@@ -45,21 +49,44 @@ schedules:
         - master
     always: "true"
 
+parameters:
+  # Routine scheduled runs are incremental on the prod pool. Set this true for a
+  # manual run to force a clean full rebuild from NVD (~7h) on the 9h sandbox
+  # pool — e.g. if the blob mirror is ever lost/corrupted. The mirror is
+  # decoupled from consumers, so a long full run blocks nobody.
+  - name: fullRebuild
+    displayName: "Force a full rebuild from NVD (9h sandbox pool; skips incremental seed)"
+    type: boolean
+    default: false
+
 variables:
   serviceConnection: azurerm-prod
   keyvaultName: cftptl-intsvc
-  # TODO(DTSPO-32997): set to the provisioned storage account + container.
-  storageAccount: "REPLACE_WITH_STORAGE_ACCOUNT"
+  # The sbox DB-update consumer reads its SAS from a different vault, so the
+  # mirror syncs the same token there each run (the blob itself is in prod).
+  sboxServiceConnection: azurerm-sandbox
+  sboxKeyvaultName: cftsbox-intsvc
+  # DTSPO-32997: dedicated OWASP NVD mirror storage (core-infra-intsvc-rg).
+  storageAccount: "owaspnvdmirrorcftptl"
   storageContainer: "nvd"
+  # Read-SAS lifetime; regenerated every run so consumers never hit an expiry.
+  sasValidDays: "90"
   # Pin to a verified release of open-vulnerability-cli (vulnz).
   vulnzVersion: "9.0.4"
 
 jobs:
   - job: nvd_mirror
     displayName: Mirror NVD datafeed to Blob Storage
-    pool:
-      name: "hmcts-cftptl-agent-pool"
-    timeoutInMinutes: 120
+    # Routine 6-hourly runs use the prod pool (3h cap) and update incrementally.
+    # A forced full rebuild needs the 9h sandbox pool to fit the ~7h cold pull.
+    ${{ if eq(parameters.fullRebuild, true) }}:
+      pool:
+        name: "hmcts-sandbox-agent-pool"
+      timeoutInMinutes: 540
+    ${{ else }}:
+      pool:
+        name: "hmcts-cftptl-agent-pool"
+      timeoutInMinutes: 120
     steps:
       - task: AzureKeyVault@2
         displayName: "Get secrets from Keyvault"
@@ -83,26 +110,49 @@ jobs:
         env:
           VULNZ_VERSION: $(vulnzVersion)
 
+      # Incremental runs seed ./cache from the published mirror first so vulnz
+      # only fetches the delta. A full rebuild skips this so vulnz pulls all years.
+      - ${{ if eq(parameters.fullRebuild, false) }}:
+        - task: AzureCLI@2
+          displayName: "Seed local cache from existing mirror (incremental)"
+          inputs:
+            azureSubscription: ${{ variables.serviceConnection }}
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              set -euo pipefail
+              # Pull the currently published cache so vulnz only fetches the delta
+              # (the 'modified' feed + recently changed years) instead of rebuilding
+              # all ~25 years from scratch — a full pull exceeds the agent time cap.
+              # On the very first run the container is empty and this is a no-op.
+              mkdir -p cache
+              az storage blob download-batch \
+                --account-name "$(storageAccount)" \
+                --source "$(storageContainer)" \
+                --destination cache \
+                --auth-mode login
+              echo "----- seeded cache -----"
+              ls -lh cache || true
+
       - task: Bash@3
-        displayName: "Build NVD datafeed cache"
+        displayName: "Build/refresh NVD datafeed cache (vulnz)"
         inputs:
           targetType: inline
           script: |
             set -euo pipefail
-            rm -rf cache && mkdir -p cache
-            # vulnz 8.0.0+ needs Java 17. Verify the agent's java:
+            # vulnz 8.0.0+ requires Java 17 — the agent ships it as JAVA_HOME_17_X64.
+            export JAVA_HOME="${JAVA_HOME_17_X64:-$JAVA_HOME}"
+            export PATH="${JAVA_HOME}/bin:${PATH}"
             java -version
-            # Produces cache.properties, nvdcve-modified.json.gz and
+            mkdir -p cache
+            # Run against the pre-seeded ./cache so vulnz updates incrementally.
+            # Produces/refreshes cache.properties, nvdcve-modified.json.gz and
             # nvdcve-<year>.json.gz (+ .meta files) under ./cache
             java -Xmx2g -XX:+UseStringDeduplication \
-              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache
+              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache \
+              --recordsPerPage=500 --delay=1000
             echo "----- cache contents -----"
             ls -lh cache
-            # Docker alternative (if the agent lacks Java 17 but has Docker):
-            #   docker run --rm -e NVD_API_KEY="${NVD_API_KEY}" -e JAVA_OPT=-Xmx2g \
-            #     -v "$(pwd)/cache:/usr/local/apache2/htdocs" \
-            #     jeremylong/open-vulnerability-data-mirror:v${VULNZ_VERSION} \
-            #     /mirror.sh
         env:
           VULNZ_VERSION: $(vulnzVersion)
           NVD_API_KEY: $(nvd-api-key)
@@ -124,3 +174,52 @@ jobs:
               --source cache \
               --overwrite true \
               --auth-mode login
+
+      - task: AzureCLI@2
+        name: rotateSas
+        displayName: "Rotate read SAS into Key Vault for consumers"
+        inputs:
+          azureSubscription: ${{ variables.serviceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            # Mint a fresh container read SAS every run and store it in Key Vault.
+            # Consumers read 'nvd-datafeed-sas' at build time, so the SAS is always
+            # renewed long before it expires — no manual rotation, no silent 403s.
+            KEY=$(az storage account keys list \
+              --account-name "$(storageAccount)" \
+              --query '[0].value' -o tsv)
+            EXPIRY=$(date -u -d "+$(sasValidDays) days" '+%Y-%m-%dT%H:%MZ')
+            SAS=$(az storage container generate-sas \
+              --account-name "$(storageAccount)" \
+              --account-key "$KEY" \
+              --name "$(storageContainer)" \
+              --permissions rl \
+              --expiry "$EXPIRY" \
+              --https-only -o tsv)
+            az keyvault secret set \
+              --vault-name "$(keyvaultName)" \
+              --name nvd-datafeed-sas \
+              --value "$SAS" >/dev/null
+            # Hand the token to the sandbox-vault sync step (masked in logs).
+            echo "##vso[task.setvariable variable=sasToken;issecret=true;isOutput=true]$SAS"
+            echo "Rotated nvd-datafeed-sas in $(keyvaultName) (expires ${EXPIRY})"
+
+      - task: AzureCLI@2
+        displayName: "Sync read SAS into sandbox Key Vault"
+        inputs:
+          azureSubscription: ${{ variables.sboxServiceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            # The sbox DB-update pipeline reads 'nvd-datafeed-sas' from
+            # cftsbox-intsvc; keep it in lock-step with the prod vault.
+            az keyvault secret set \
+              --vault-name "$(sboxKeyvaultName)" \
+              --name nvd-datafeed-sas \
+              --value "$SAS_TOKEN" >/dev/null
+            echo "Synced nvd-datafeed-sas to $(sboxKeyvaultName)"
+        env:
+          SAS_TOKEN: $(rotateSas.sasToken)

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -25,6 +25,14 @@
 trigger: none
 pr: none
 
+schedules:
+- cron: '0 22 * * *'
+  displayName: Nightly seed attempt at 22:00 UTC (23:00 BST)
+  branches:
+    include:
+    - platops/dstpo-32997owasp-nvd-download
+  always: 'true'
+
 parameters:
   - name: environment
     displayName: Target environment

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -93,16 +93,13 @@ jobs:
             fi
             java -version
             rm -rf cache && mkdir -p cache
-            # Pass the NVD API key when available so the cache build is
-            # authenticated (much higher rate limit; far fewer 403/timeout retries).
-            NVD_KEY_ARG=()
-            if [ -n "${NVD_API_KEY:-}" ]; then
-              NVD_KEY_ARG=(--nvd-api-key "${NVD_API_KEY}")
-            fi
+            # vulnz reads the NVD API key from the NVD_API_KEY env var (set below),
+            # which authenticates the build for a much higher rate limit. No CLI
+            # flag is needed (and --apikey is discouraged by the tool).
             # Produces cache.properties, nvdcve-modified.json.gz and
             # nvdcve-<year>.json.gz (+ .meta) under ./cache. Re-running resumes.
             java -Xmx2g -XX:+UseStringDeduplication \
-              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache "${NVD_KEY_ARG[@]}"
+              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache
             echo "----- cache contents -----"
             ls -lh cache
             # Docker alternative (if the agent lacks Java 17 but has Docker):

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -99,7 +99,8 @@ jobs:
             # Produces cache.properties, nvdcve-modified.json.gz and
             # nvdcve-<year>.json.gz (+ .meta) under ./cache. Re-running resumes.
             java -Xmx2g -XX:+UseStringDeduplication \
-              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache
+              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache \
+              --recordsPerPage=500 --delay=1000
             echo "----- cache contents -----"
             ls -lh cache
             # Docker alternative (if the agent lacks Java 17 but has Docker):

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -89,32 +89,23 @@ jobs:
           VULNZ_VERSION: ${{ parameters.vulnzVersion }}
 
       - task: Bash@3
-        displayName: "Build NVD cache (resumable)"
+        displayName: "Build NVD cache (Docker mirror)"
         inputs:
           targetType: inline
           script: |
             set -euo pipefail
-            # vulnz 8.0.0+ needs Java 17; prefer the agent's JDK 17 if available.
-            if [ -n "${JAVA_HOME_17_X64:-}" ]; then
-              export JAVA_HOME="${JAVA_HOME_17_X64}"
-              export PATH="${JAVA_HOME}/bin:${PATH}"
-            fi
-            java -version
             mkdir -p cache
-            # vulnz reads the NVD API key from the NVD_API_KEY env var (set below),
-            # which authenticates the build for a much higher rate limit. No CLI
-            # flag is needed (and --apikey is discouraged by the tool).
-            # Produces cache.properties, nvdcve-modified.json.gz and
-            # nvdcve-<year>.json.gz (+ .meta) under ./cache. Re-running resumes.
-            java -Xmx2g -XX:+UseStringDeduplication \
-              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache \
-              --recordsPerPage=500 --delay=1000
+            # Use the maintainer's purpose-built mirror image instead of invoking
+            # the jar directly. It is more robust for full cache builds and avoids
+            # the JVM/agent OOM-abandonment seen with the jar. mirror.sh writes
+            # cache.properties + nvdcve-<year>.json.gz into the mounted htdocs dir.
+            docker run --rm \
+              -e NVD_API_KEY="${NVD_API_KEY}" \
+              -e JAVA_OPT=-Xmx2g \
+              -v "$(pwd)/cache:/usr/local/apache2/htdocs" \
+              jeremylong/open-vulnerability-data-mirror:v${VULNZ_VERSION} /mirror.sh
             echo "----- cache contents -----"
             ls -lh cache
-            # Docker alternative (if the agent lacks Java 17 but has Docker):
-            #   docker run --rm -e NVD_API_KEY="${NVD_API_KEY}" -e JAVA_OPT=-Xmx2g \
-            #     -v "$(pwd)/cache:/usr/local/apache2/htdocs" \
-            #     jeremylong/open-vulnerability-data-mirror:v${VULNZ_VERSION} /mirror.sh
         env:
           VULNZ_VERSION: ${{ parameters.vulnzVersion }}
           NVD_API_KEY: $(nvd-api-key)

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -92,7 +92,7 @@ jobs:
               export PATH="${JAVA_HOME}/bin:${PATH}"
             fi
             java -version
-            rm -rf cache && mkdir -p cache
+            mkdir -p cache
             # vulnz reads the NVD API key from the NVD_API_KEY env var (set below),
             # which authenticates the build for a much higher rate limit. No CLI
             # flag is needed (and --apikey is discouraged by the tool).

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -93,10 +93,16 @@ jobs:
             fi
             java -version
             rm -rf cache && mkdir -p cache
+            # Pass the NVD API key when available so the cache build is
+            # authenticated (much higher rate limit; far fewer 403/timeout retries).
+            NVD_KEY_ARG=()
+            if [ -n "${NVD_API_KEY:-}" ]; then
+              NVD_KEY_ARG=(--nvd-api-key "${NVD_API_KEY}")
+            fi
             # Produces cache.properties, nvdcve-modified.json.gz and
             # nvdcve-<year>.json.gz (+ .meta) under ./cache. Re-running resumes.
             java -Xmx2g -XX:+UseStringDeduplication \
-              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache
+              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache "${NVD_KEY_ARG[@]}"
             echo "----- cache contents -----"
             ls -lh cache
             # Docker alternative (if the agent lacks Java 17 but has Docker):

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -89,21 +89,24 @@ jobs:
           VULNZ_VERSION: ${{ parameters.vulnzVersion }}
 
       - task: Bash@3
-        displayName: "Build NVD cache (Docker mirror)"
+        displayName: "Build NVD cache (resumable)"
         inputs:
           targetType: inline
           script: |
             set -euo pipefail
+            # vulnz 8.0.0+ needs Java 17; prefer the agent's JDK 17 if available.
+            if [ -n "${JAVA_HOME_17_X64:-}" ]; then
+              export JAVA_HOME="${JAVA_HOME_17_X64}"
+              export PATH="${JAVA_HOME}/bin:${PATH}"
+            fi
+            java -version
             mkdir -p cache
-            # Use the maintainer's purpose-built mirror image instead of invoking
-            # the jar directly. It is more robust for full cache builds and avoids
-            # the JVM/agent OOM-abandonment seen with the jar. mirror.sh writes
-            # cache.properties + nvdcve-<year>.json.gz into the mounted htdocs dir.
-            docker run --rm \
-              -e NVD_API_KEY="${NVD_API_KEY}" \
-              -e JAVA_OPT=-Xmx2g \
-              -v "$(pwd)/cache:/usr/local/apache2/htdocs" \
-              jeremylong/open-vulnerability-data-mirror:v${VULNZ_VERSION} /mirror.sh
+            # vulnz reads the NVD API key from the NVD_API_KEY env var (set below).
+            # NOTE: these K8s pod agents have no Docker socket, so the maintainer's
+            # mirror container is not an option here; we invoke the jar directly.
+            java -Xmx2g -XX:+UseStringDeduplication \
+              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache \
+              --recordsPerPage=500 --delay=1000
             echo "----- cache contents -----"
             ls -lh cache
         env:

--- a/azure-pipelines-nvd-seed.yml
+++ b/azure-pipelines-nvd-seed.yml
@@ -1,0 +1,127 @@
+# =============================================================================
+# DTSPO-32997 — One-off NVD seed (pragmatic interim, no new infra)
+# =============================================================================
+#
+# Purpose
+#   Get the shared OWASP DB current WITHOUT paging the flaky live NVD API.
+#   1. Build a local NVD cache on the agent with open-vulnerability-cli (vulnz).
+#      This is resumable and survives NVD HTTP/2 instability — re-run the job if
+#      the cache build is interrupted; completed year files are kept.
+#   2. Load that cache into Postgres in one fast pass via DependencyCheck's
+#      datafeed support (file: URL), which the engine reads locally instead of
+#      hitting the NVD API.
+#
+#   Once the DB is fresh, the normal scheduled pipeline goes back to small,
+#   fast incremental updates.
+#
+# This is a MANUAL pipeline (no schedule). Run it on-demand, sandbox first.
+#
+# Notes
+#   - vulnz 8.0.0+ requires Java 17. The job selects JAVA_HOME_17_X64 if present;
+#     otherwise install Java 17 on the agent or use the Docker alternative below.
+#   - DependencyCheck supports file/http/https datafeed URLs (Downloader.java).
+# =============================================================================
+
+trigger: none
+pr: none
+
+parameters:
+  - name: environment
+    displayName: Target environment
+    type: string
+    default: sandbox
+    values:
+      - sandbox
+      - prod
+  - name: vulnzVersion
+    displayName: open-vulnerability-cli (vulnz) version
+    type: string
+    default: "9.0.4"
+
+variables:
+  ${{ if eq(parameters.environment, 'prod') }}:
+    serviceConnection: azurerm-prod
+    keyvaultName: cftptl-intsvc
+    dbHost: owaspdependency-prod.postgres.database.azure.com
+  ${{ if eq(parameters.environment, 'sandbox') }}:
+    serviceConnection: azurerm-sandbox
+    keyvaultName: cftsbox-intsvc
+    dbHost: owaspdependency-sandbox.postgres.database.azure.com
+
+jobs:
+  - job: nvd_seed
+    displayName: Seed OWASP DB from a local NVD cache (${{ parameters.environment }})
+    ${{ if eq(parameters.environment, 'prod') }}:
+      pool:
+        name: "hmcts-cftptl-agent-pool"
+    ${{ if eq(parameters.environment, 'sandbox') }}:
+      pool:
+        name: "hmcts-sandbox-agent-pool"
+    timeoutInMinutes: 180
+    steps:
+      - task: AzureKeyVault@2
+        displayName: "Get secrets from Keyvault"
+        inputs:
+          azureSubscription: ${{ variables.serviceConnection }}
+          keyVaultName: ${{ variables.keyvaultName }}
+          secretsFilter: "OWASPPostgresDb-v15-Password,OWASPPostgresDb-v15-Account,nvd-api-key"
+          RunAsPreJob: true
+
+      - task: Bash@3
+        displayName: "Download open-vulnerability-cli (vulnz)"
+        inputs:
+          targetType: inline
+          script: |
+            set -euo pipefail
+            JAR="vulnz-${VULNZ_VERSION}.jar"
+            URL="https://github.com/jeremylong/open-vulnerability-cli/releases/download/v${VULNZ_VERSION}/${JAR}"
+            echo "Downloading ${URL}"
+            curl -sSfL "${URL}" -o "${JAR}"
+        env:
+          VULNZ_VERSION: ${{ parameters.vulnzVersion }}
+
+      - task: Bash@3
+        displayName: "Build NVD cache (resumable)"
+        inputs:
+          targetType: inline
+          script: |
+            set -euo pipefail
+            # vulnz 8.0.0+ needs Java 17; prefer the agent's JDK 17 if available.
+            if [ -n "${JAVA_HOME_17_X64:-}" ]; then
+              export JAVA_HOME="${JAVA_HOME_17_X64}"
+              export PATH="${JAVA_HOME}/bin:${PATH}"
+            fi
+            java -version
+            rm -rf cache && mkdir -p cache
+            # Produces cache.properties, nvdcve-modified.json.gz and
+            # nvdcve-<year>.json.gz (+ .meta) under ./cache. Re-running resumes.
+            java -Xmx2g -XX:+UseStringDeduplication \
+              -jar "vulnz-${VULNZ_VERSION}.jar" cve --cache --directory ./cache
+            echo "----- cache contents -----"
+            ls -lh cache
+            # Docker alternative (if the agent lacks Java 17 but has Docker):
+            #   docker run --rm -e NVD_API_KEY="${NVD_API_KEY}" -e JAVA_OPT=-Xmx2g \
+            #     -v "$(pwd)/cache:/usr/local/apache2/htdocs" \
+            #     jeremylong/open-vulnerability-data-mirror:v${VULNZ_VERSION} /mirror.sh
+        env:
+          VULNZ_VERSION: ${{ parameters.vulnzVersion }}
+          NVD_API_KEY: $(nvd-api-key)
+
+      - task: Gradle@2
+        displayName: "Running OWASP V15 DB migrations"
+        inputs:
+          gradleWrapperFile: "gradlew"
+          options: "--build-file build-v10.gradle -DfailBuild='true' -Dflyway.url=jdbc:postgresql://$(dbHost)/owaspdependencycheck -Dflyway.user=$(OWASPPostgresDb-v15-Account) -Dflyway.password=$(OWASPPostgresDb-v15-Password) -Dflyway.locations=filesystem:db-migrations/v10"
+          tasks: "flywayMigrate"
+          gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
+
+      - task: Gradle@2
+        displayName: "Load NVD cache into OWASP V15 DB (datafeed)"
+        inputs:
+          gradleWrapperFile: "gradlew"
+          # Reads the local cache via the file: datafeed URL instead of paging the
+          # live NVD API. {0} is substituted with the year; cache.properties must
+          # sit alongside the gz files (vulnz writes it into ./cache).
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://$(dbHost)/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Dnvd.api.datafeed.url=file:$(System.DefaultWorkingDirectory)/cache/nvdcve-{0}.json.gz -Ddatabase.batchinsert.enabled='true'"
+          tasks: "dependencyCheckUpdate"
+          gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError

--- a/azure-pipelines-sbox.yml
+++ b/azure-pipelines-sbox.yml
@@ -37,6 +37,6 @@ jobs:
         displayName: "Updating OWASP V15 DB"
         inputs:
           gradleWrapperFile: "gradlew"
-          options: "--build-file build-v10.gradle -DfailOnError='true' -Dorg.gradle.debug='true' --info -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Dorg.gradle.debug='true' --info -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: "dependencyCheckUpdate"
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError

--- a/azure-pipelines-sbox.yml
+++ b/azure-pipelines-sbox.yml
@@ -15,6 +15,12 @@ jobs:
     variables:
       serviceConnection: azurerm-sandbox
       keyvaultName: cftsbox-intsvc
+      # DTSPO-32997 Option B: once azure-pipelines-nvd-mirror.yml is publishing the
+      # NVD feed to blob storage, set this to the mirror URL, e.g.
+      #   https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz
+      # then append -Dnvd.api.datafeed.url=$(nvdDatafeedUrl) to the
+      # 'Updating OWASP V15 DB' options below. Validate here on sbox first.
+      nvdDatafeedUrl: ""
     timeoutInMinutes: 600
     steps:
       - task: AzureKeyVault@2

--- a/azure-pipelines-sbox.yml
+++ b/azure-pipelines-sbox.yml
@@ -15,12 +15,13 @@ jobs:
     variables:
       serviceConnection: azurerm-sandbox
       keyvaultName: cftsbox-intsvc
-      # DTSPO-32997 Option B: once azure-pipelines-nvd-mirror.yml is publishing the
-      # NVD feed to blob storage, set this to the mirror URL, e.g.
-      #   https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz
-      # then append -Dnvd.api.datafeed.url=$(nvdDatafeedUrl) to the
-      # 'Updating OWASP V15 DB' options below. Validate here on sbox first.
-      nvdDatafeedUrl: ""
+      # DTSPO-32997 Option B: read the NVD yearly feeds from the blob mirror
+      # (azure-pipelines-nvd-mirror.yml) instead of paging the live NVD API. {0}
+      # is substituted by DependencyCheck with the year; the read SAS is appended
+      # at runtime from the Key Vault secret 'nvd-datafeed-sas'. The mirror runs
+      # in prod but syncs the SAS into cftsbox-intsvc each run. Validate here on
+      # sbox first before relying on it in prod.
+      nvdDatafeedUrl: "https://owaspnvdmirrorcftptl.blob.core.windows.net/nvd/nvdcve-{0}.json.gz"
     timeoutInMinutes: 600
     steps:
       - task: AzureKeyVault@2
@@ -28,7 +29,7 @@ jobs:
         inputs:
           azureSubscription: ${{ variables.serviceConnection }}
           keyVaultName: ${{ variables.keyvaultName }}
-          secretsFilter: "OWASPPostgresDb-v15-Password,OWASPPostgresDb-v15-Account,nvd-api-key"
+          secretsFilter: "OWASPPostgresDb-v15-Password,OWASPPostgresDb-v15-Account,nvd-api-key,nvd-datafeed-sas"
           RunAsPreJob: true
 
       - task: Gradle@2
@@ -43,6 +44,6 @@ jobs:
         displayName: "Updating OWASP V15 DB"
         inputs:
           gradleWrapperFile: "gradlew"
-          options: "--build-file build-v10.gradle -DfailOnError='true' -Dorg.gradle.debug='true' --info -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Dorg.gradle.debug='true' --info -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Dnvd.api.datafeed.url=$(nvdDatafeedUrl)?$(nvd-datafeed-sas) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: "dependencyCheckUpdate"
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError

--- a/azure-pipelines-sbox.yml
+++ b/azure-pipelines-sbox.yml
@@ -15,13 +15,15 @@ jobs:
     variables:
       serviceConnection: azurerm-sandbox
       keyvaultName: cftsbox-intsvc
-      # DTSPO-32997 Option B: read the NVD yearly feeds from the blob mirror
-      # (azure-pipelines-nvd-mirror.yml) instead of paging the live NVD API. {0}
-      # is substituted by DependencyCheck with the year; the read SAS is appended
-      # at runtime from the Key Vault secret 'nvd-datafeed-sas'. The mirror runs
-      # in prod but syncs the SAS into cftsbox-intsvc each run. Validate here on
-      # sbox first before relying on it in prod.
-      nvdDatafeedUrl: "https://owaspnvdmirrorcftptl.blob.core.windows.net/nvd/nvdcve-{0}.json.gz"
+      # DTSPO-32997 Option B: the NVD feeds are mirrored to blob storage by
+      # azure-pipelines-nvd-mirror.yml. We download them to ./cache with the read
+      # SAS (synced into cftsbox-intsvc by the mirror), then point DependencyCheck
+      # at the local files via a file: datafeed URL. ODC string-appends to the
+      # configured URL when building each feed / cache.properties URL, so it can't
+      # consume a blob URL carrying a ?<SAS> query string directly - hence
+      # download-then-read-local. Validate here on sbox first.
+      mirrorStorageAccount: owaspnvdmirrorcftptl
+      mirrorStorageContainer: nvd
     timeoutInMinutes: 600
     steps:
       - task: AzureKeyVault@2
@@ -40,10 +42,33 @@ jobs:
           tasks: "flywayMigrate"
           gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 
+      - task: AzureCLI@2
+        displayName: "Download NVD datafeed from blob mirror"
+        inputs:
+          azureSubscription: ${{ variables.serviceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            # ODC can't read a SAS-bearing blob URL directly, so pull the mirrored
+            # feeds (gz + .meta + cache.properties) to a local cache and let ODC
+            # read them via a file: datafeed URL.
+            mkdir -p cache
+            az storage blob download-batch \
+              --account-name "$(mirrorStorageAccount)" \
+              --source "$(mirrorStorageContainer)" \
+              --destination cache \
+              --sas-token "$NVD_SAS" \
+              --no-progress
+            echo "----- cache contents -----"
+            ls -lh cache
+        env:
+          NVD_SAS: $(nvd-datafeed-sas)
+
       - task: Gradle@2
         displayName: "Updating OWASP V15 DB"
         inputs:
           gradleWrapperFile: "gradlew"
-          options: "--build-file build-v10.gradle -DfailOnError='true' -Dorg.gradle.debug='true' --info -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Dnvd.api.datafeed.url=$(nvdDatafeedUrl)?$(nvd-datafeed-sas) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Dorg.gradle.debug='true' --info -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-sandbox.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Dnvd.api.datafeed.url=file:$(System.DefaultWorkingDirectory)/cache/nvdcve-{0}.json.gz -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: "dependencyCheckUpdate"
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,13 @@ jobs:
     variables:
       serviceConnection: azurerm-prod
       keyvaultName: cftptl-intsvc
+      # DTSPO-32997 Option B: once azure-pipelines-nvd-mirror.yml is publishing the
+      # NVD feed to blob storage, set this to the mirror URL, e.g.
+      #   https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz
+      # then append -Dnvd.api.datafeed.url=$(nvdDatafeedUrl) to the
+      # 'Updating OWASP V15 DB' options below. This reads the gz feeds instead of
+      # paging the live NVD API, cutting the update from hours to minutes.
+      nvdDatafeedUrl: ""
     timeoutInMinutes: 600
     steps:
       - task: AzureKeyVault@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,13 +16,13 @@ jobs:
     variables:
       serviceConnection: azurerm-prod
       keyvaultName: cftptl-intsvc
-      # DTSPO-32997 Option B: once azure-pipelines-nvd-mirror.yml is publishing the
-      # NVD feed to blob storage, set this to the mirror URL, e.g.
-      #   https://<account>.blob.core.windows.net/nvd/nvdcve-{0}.json.gz
-      # then append -Dnvd.api.datafeed.url=$(nvdDatafeedUrl) to the
-      # 'Updating OWASP V15 DB' options below. This reads the gz feeds instead of
-      # paging the live NVD API, cutting the update from hours to minutes.
-      nvdDatafeedUrl: ""
+      # DTSPO-32997 Option B: read the NVD yearly feeds from the blob mirror
+      # (azure-pipelines-nvd-mirror.yml) instead of paging the live NVD API. {0}
+      # is substituted by DependencyCheck with the year; the read SAS is appended
+      # at runtime from the Key Vault secret 'nvd-datafeed-sas' (rotated by the
+      # mirror), so it never lapses. This cuts the bulk update from hours to
+      # minutes; nvd.api.key is kept only for the small recent 'modified' window.
+      nvdDatafeedUrl: "https://owaspnvdmirrorcftptl.blob.core.windows.net/nvd/nvdcve-{0}.json.gz"
     timeoutInMinutes: 600
     steps:
       - task: AzureKeyVault@2
@@ -30,7 +30,7 @@ jobs:
         inputs:
           azureSubscription: ${{ variables.serviceConnection }}
           keyVaultName: ${{ variables.keyvaultName }}
-          secretsFilter: 'OWASPPostgresDb-v15-Password,OWASPPostgresDb-v15-Account,nvd-api-key'
+          secretsFilter: 'OWASPPostgresDb-v15-Password,OWASPPostgresDb-v15-Account,nvd-api-key,nvd-datafeed-sas'
           RunAsPreJob: true
 
       - task: Gradle@2
@@ -45,6 +45,6 @@ jobs:
         displayName: 'Updating OWASP V15 DB'
         inputs:
           gradleWrapperFile: 'gradlew'
-          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Dnvd.api.datafeed.url=$(nvdDatafeedUrl)?$(nvd-datafeed-sas) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: 'dependencyCheckUpdate'
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,6 @@ jobs:
         displayName: 'Updating OWASP V15 DB'
         inputs:
           gradleWrapperFile: 'gradlew'
-          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: 'dependencyCheckUpdate'
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,13 +16,15 @@ jobs:
     variables:
       serviceConnection: azurerm-prod
       keyvaultName: cftptl-intsvc
-      # DTSPO-32997 Option B: read the NVD yearly feeds from the blob mirror
-      # (azure-pipelines-nvd-mirror.yml) instead of paging the live NVD API. {0}
-      # is substituted by DependencyCheck with the year; the read SAS is appended
-      # at runtime from the Key Vault secret 'nvd-datafeed-sas' (rotated by the
-      # mirror), so it never lapses. This cuts the bulk update from hours to
-      # minutes; nvd.api.key is kept only for the small recent 'modified' window.
-      nvdDatafeedUrl: "https://owaspnvdmirrorcftptl.blob.core.windows.net/nvd/nvdcve-{0}.json.gz"
+      # DTSPO-32997 Option B: the NVD feeds are mirrored to blob storage by
+      # azure-pipelines-nvd-mirror.yml. We download them to ./cache with the read
+      # SAS, then point DependencyCheck at the local files via a file: datafeed
+      # URL. ODC builds each feed / cache.properties URL by string-appending to
+      # the configured URL, so it cannot consume a blob URL carrying a ?<SAS>
+      # query string directly - hence download-then-read-local. nvd.api.key is
+      # kept only for the small recent 'modified' window.
+      mirrorStorageAccount: owaspnvdmirrorcftptl
+      mirrorStorageContainer: nvd
     timeoutInMinutes: 600
     steps:
       - task: AzureKeyVault@2
@@ -41,10 +43,33 @@ jobs:
           tasks: 'flywayMigrate'
           gradleOptions: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
 
+      - task: AzureCLI@2
+        displayName: 'Download NVD datafeed from blob mirror'
+        inputs:
+          azureSubscription: ${{ variables.serviceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            # ODC can't read a SAS-bearing blob URL directly, so pull the mirrored
+            # feeds (gz + .meta + cache.properties) to a local cache and let ODC
+            # read them via a file: datafeed URL.
+            mkdir -p cache
+            az storage blob download-batch \
+              --account-name "$(mirrorStorageAccount)" \
+              --source "$(mirrorStorageContainer)" \
+              --destination cache \
+              --sas-token "$NVD_SAS" \
+              --no-progress
+            echo "----- cache contents -----"
+            ls -lh cache
+        env:
+          NVD_SAS: $(nvd-datafeed-sas)
+
       - task: Gradle@2
         displayName: 'Updating OWASP V15 DB'
         inputs:
           gradleWrapperFile: 'gradlew'
-          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Dnvd.api.datafeed.url=$(nvdDatafeedUrl)?$(nvd-datafeed-sas) -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
+          options: "--build-file build-v10.gradle -DfailOnError='true' -Ddata.driver_name=org.postgresql.Driver -Ddata.connection_string=jdbc:postgresql://owaspdependency-prod.postgres.database.azure.com/owaspdependencycheck -Ddata.user=$(OWASPPostgresDb-v15-Account) -Dnvd.api.key=$(nvd-api-key) -Dnvd.api.delay=10000 -Dnvd.api.max.retry.count=30 -Dnvd.api.datafeed.url=file:$(System.DefaultWorkingDirectory)/cache/nvdcve-{0}.json.gz -Ddata.password=$(OWASPPostgresDb-v15-Password) -Ddatabase.batchinsert.enabled='true'"
           tasks: 'dependencyCheckUpdate'
           gradleOptions: -Xmx3g -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
### Jira link
[
<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)](https://tools.hmcts.net/jira/browse/DTSPO-32997)
https://tools.hmcts.net/jira/browse/DTSPO-32990
https://tools.hmcts.net/jira/browse/DTSPO-33091

### Change description
## Problem
The shared OWASP DependencyCheck DB-update pipelines page the live NVD API directly and fail intermittently (rate-limits / timeouts), leaving the central DB stale and downstream scans broken.

## Solution (Option B)
Mirror the NVD datafeeds into Azure Blob Storage (`owaspnvdmirrorcftptl`/`nvd`) and have the consumers read from the mirror instead of the live API.

Key detail: ODC's datafeed loader can't consume a SAS-bearing blob URL (it string-appends per-file paths and chokes on the `?<sas>` suffix). So consumers **download the feeds to `./cache` via `az storage blob download-batch --sas-token`, then read locally via `-Dnvd.api.datafeed.url=file:.../cache/nvdcve-{0}.json.gz`** — the proven seed-pipeline pattern. Container stays private; no blob RBAC needed by ODC.

## Changes
- `azure-pipelines.yml` (prod) + `azure-pipelines-sbox.yml` (sbox): add SAS secret, blob-download step, switch update step to `file:` datafeed URL.
- `azure-pipelines-nvd-mirror.yml`: producer builds cache with vulnz, publishes to blob, rotates a 90-day read SAS into both `cftptl-intsvc` and `cftsbox-intsvc` vaults.
- `README.md`: setup, wiring, SAS-URL incompatibility, RBAC notes.

## Validation
Sandbox run `#20260630.3` green (2h48m): 100% from mirror, **zero live NVD API calls**. DB fully populated (232k CVEs, ~1.3M software, ~1.6M refs); `properties` shows `nvd.cache.last.modified.2002`→`.2026` all current to 30 Jun 2026.

## Follow-ups before/after merge
- RBAC: `azurerm-prod` SP → Storage Blob Data Contributor + key-list on the mirror SA + secret-set on `cftptl-intsvc`; `azurerm-sandbox` SP → secret-set on `cftsbox-intsvc`.
- First prod run does a one-time full load (~3h), then 3-hourly incrementals.
- Point downstream Jenkins `dependencyCheckAggregate` at the mirror.

## Rollback
Revert the consumer changes — pipelines fall back to live-API paging.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
